### PR TITLE
added identity_ids check when type=UserAssigned

### DIFF
--- a/modules/webapps/appservice/module.tf
+++ b/modules/webapps/appservice/module.tf
@@ -32,6 +32,8 @@ resource "azurerm_app_service" "app_service" {
       identity_ids = lower(var.identity.type) == "userassigned" ? local.managed_identities : null
     }
   }
+  
+  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
 
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -23,7 +23,7 @@ resource "azurerm_app_service_slot" "slots" {
     }
   }
   
-  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
+  key_vault_reference_identity_id = can(var.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.key_vault_reference_identity.key].id : try(var.key_vault_reference_identity.id, null)
 
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -19,7 +19,7 @@ resource "azurerm_app_service_slot" "slots" {
 
     content {
       type         = try(var.identity.type, null)
-      identity_ids = try(var.identity.identity_ids, null)
+      identity_ids = lower(var.identity.type) == "userassigned" ? local.identity_ids : null
     }
   }
 

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -19,7 +19,7 @@ resource "azurerm_app_service_slot" "slots" {
 
     content {
       type         = try(var.identity.type, null)
-      identity_ids = lower(var.identity.type) == "userassigned" ? local.identity_ids : null
+      identity_ids = lower(var.identity.type) == "userassigned" ? local.managed_identities : null
     }
   }
 

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -22,6 +22,8 @@ resource "azurerm_app_service_slot" "slots" {
       identity_ids = lower(var.identity.type) == "userassigned" ? local.managed_identities : null
     }
   }
+  
+  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
 
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []

--- a/modules/webapps/appservice/slot.tf
+++ b/modules/webapps/appservice/slot.tf
@@ -23,7 +23,7 @@ resource "azurerm_app_service_slot" "slots" {
     }
   }
   
-  key_vault_reference_identity_id = can(var.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.key_vault_reference_identity.key].id : try(var.key_vault_reference_identity.id, null)
+  key_vault_reference_identity_id = can(var.settings.key_vault_reference_identity.key) ? var.combined_objects.managed_identities[try(var.settings.identity.lz_key, var.client_config.landingzone_key)][var.settings.key_vault_reference_identity.key].id : try(var.settings.key_vault_reference_identity.id, null)
 
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []


### PR DESCRIPTION
When an Managed instance is of type = "UserAssigned" the identity block for webapp slot, doesn't differentiate between the types.
this change makes it that if reads from the right variable if given type UserAssigned