### PR TITLE
Update local to check if any of the maps are set, if not, then set ap…

### DIFF
--- a/modules/webapps/appservice/main.tf
+++ b/modules/webapps/appservice/main.tf
@@ -15,8 +15,18 @@ locals {
 
   arm_filename = "${path.module}/arm_site_config.json"
 
-  app_settings = merge(try(var.app_settings, {}), try(local.dynamic_settings_to_process, {}), var.application_insight == null ? {} :
-    {
+  app_settings = length(merge(
+    try(var.app_settings, {}),
+    try(local.dynamic_settings_to_process, {}),
+    var.application_insight == null ? {} : {
+      "APPINSIGHTS_INSTRUMENTATIONKEY"             = var.application_insight.instrumentation_key,
+      "APPLICATIONINSIGHTS_CONNECTION_STRING"      = var.application_insight.connection_string,
+      "ApplicationInsightsAgent_EXTENSION_VERSION" = "~2"
+    }
+  )) == 0 ? null : merge(
+    try(var.app_settings, {}),
+    try(local.dynamic_settings_to_process, {}),
+    var.application_insight == null ? {} : {
       "APPINSIGHTS_INSTRUMENTATIONKEY"             = var.application_insight.instrumentation_key,
       "APPLICATIONINSIGHTS_CONNECTION_STRING"      = var.application_insight.connection_string,
       "ApplicationInsightsAgent_EXTENSION_VERSION" = "~2"


### PR DESCRIPTION
The expected behaviour is:
When you do not set the "app_settings" variable, the module should not touch the app_settings. This way you can have your deployment process set these app_settings instead of the IaC.

The logic here is:
**OLD:**
if the merge map (var.app_settings, local.dynamic_settings_to_process and var.application_insight) results in an empty map {}, then set the app_settings to "{}". **_<-- this will wipe out any settings that are set through different means_**

**NEW:**
if the merge map (var.app_settings, local.dynamic_settings_to_process and var.application_insight) results in an empty map {}, then set the app_settings to "null".

It does this by using the length of the merge outcome, if is 0 (empty map) then it will set the value to "null", otherwise it will use the input given to the map.