### PR TITLE
base_tags is expecting a boolean, not a map

### DIFF
--- a/networking_private_links.tf
+++ b/networking_private_links.tf
@@ -9,15 +9,7 @@ module "private_endpoints" {
   private_endpoints = var.networking.private_endpoints
   private_dns       = local.combined_objects_private_dns
   vnet              = try(local.combined_objects_networking[each.value.lz_key][each.value.vnet_key], local.combined_objects_networking[local.client_config.landingzone_key][each.value.vnet_key])
-  base_tags = try(local.global_settings.inherit_tags, false) ? coalesce(
-    try(local.resource_groups[each.value.resource_group_key].tags, null),
-    try(local.resource_groups[each.value.lz_key][each.value.resource_group_key].tags, null),
-    try(local.combined_objects_resource_groups[each.value.lz_key][each.value.resource_group.key].tags, null),
-    try(local.combined_objects_resource_groups[each.value.lz_key][each.value.resource_group_key].tags, null),
-    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group.key].tags, null),
-    try(local.combined_objects_resource_groups[local.client_config.landingzone_key][each.value.resource_group_key].tags, null),
-    {}
-  ) : {}
+  base_tags = try(local.global_settings.inherit_tags, false)
 
   remote_objects = {
     diagnostic_storage_accounts     = local.combined_diagnostics.storage_accounts


### PR DESCRIPTION
var.base_tags is een boolean die in de global_settings gezet kan worden.
Het idee is dat als deze op true staat, hij tags van alle bovenliggende resources ook meeneemt.

De "merge" doet hij in de locals van de module zelf: modules/networking/private_links/endpoints/main.tf

locals {
  tags = var.base_tags ? merge(
    var.global_settings.tags,
    try(var.settings.tags, null)
  ) : try(var.settings.tags, null)
}
 
dus bij **var.base_tags == true:**

```
merge(
    var.global_settings.tags,
    try(var.settings.tags, null)

```
bij **var.base_tags == false:**
`try(var.settings.tags, null)`