### PR TITLE
trying to add service_bus namespaces to builtin roles

### DIFF
--- a/roles.tf
+++ b/roles.tf
@@ -149,6 +149,7 @@ locals {
     wvd_workspaces                             = local.combined_objects_wvd_workspaces
     log_analytics                              = local.current_objects_log_analytics
     route_tables                               = local.combined_objects_route_tables
+    servicebus_namespaces                      = local.combined_objects_servicebus_namespaces
   }
 
   current_objects_log_analytics = tomap(


### PR DESCRIPTION
Adding servicebus_namespaces to the roles available to the role_mappings module. Allows you to use this:

```
role_mapping = {
    built_in_role_mapping = {
        servicebus_namespaces = { <------------- this is now possible
            "namespace_dev" = {
                "Azure Service Bus Data Receiver" = {
                    managed_identities = {
                        keys                = ["mi"]
                    }
                }
            }
        }
    }
}
```