### PR TITLE
fix: Service bus tags and private endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,10 @@
         "MD025": {
             "front_matter_title": ""
         }
+    },
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#E5A0BA",
+        "titleBar.activeBackground": "#EDBED0",
+        "titleBar.activeForeground": "#300D1A"
     }
 }

--- a/logic_app.tf
+++ b/logic_app.tf
@@ -140,22 +140,22 @@ module "logic_app_standard" {
 
   for_each = local.logic_app.logic_app_standard
 
-  global_settings   = local.global_settings
-  client_config     = local.client_config
-  settings          = each.value
-  resource_groups   = local.combined_objects_resource_groups
-  storage_accounts  = local.combined_objects_storage_accounts
-  app_service_plans = local.combined_objects_app_service_plans
-  app_settings      = try(each.value.app_settings, null)
-  external_app_settings      = try(each.value.external_app_settings, false)
-  subnets           = local.combined_objects_networking
-  identity          = try(each.value.identity, null)
-  private_endpoints = try(each.value.private_endpoints, {})
-  private_dns       = local.combined_objects_private_dns
-  vnets             = local.combined_objects_networking
-  virtual_subnets   = local.combined_objects_virtual_subnets
-  base_tags         = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
-  vnet_integration  = try(each.value.vnet_integration, {})
+  global_settings       = local.global_settings
+  client_config         = local.client_config
+  settings              = each.value
+  resource_groups       = local.combined_objects_resource_groups
+  storage_accounts      = local.combined_objects_storage_accounts
+  app_service_plans     = local.combined_objects_app_service_plans
+  app_settings          = try(each.value.app_settings, null)
+  external_app_settings = try(each.value.external_app_settings, null)
+  subnets               = local.combined_objects_networking
+  identity              = try(each.value.identity, null)
+  private_endpoints     = try(each.value.private_endpoints, {})
+  private_dns           = local.combined_objects_private_dns
+  vnets                 = local.combined_objects_networking
+  virtual_subnets       = local.combined_objects_virtual_subnets
+  base_tags             = try(local.global_settings.inherit_tags, false) ? local.resource_groups[each.value.resource_group_key].tags : {}
+  vnet_integration      = try(each.value.vnet_integration, {})
 }
 
 output "logic_app_standard" {

--- a/logic_app.tf
+++ b/logic_app.tf
@@ -147,6 +147,7 @@ module "logic_app_standard" {
   storage_accounts  = local.combined_objects_storage_accounts
   app_service_plans = local.combined_objects_app_service_plans
   app_settings      = try(each.value.app_settings, null)
+  external_app_settings      = try(each.value.external_app_settings, false)
   subnets           = local.combined_objects_networking
   identity          = try(each.value.identity, null)
   private_endpoints = try(each.value.private_endpoints, {})

--- a/modules/logic_app/standard/variables.tf
+++ b/modules/logic_app/standard/variables.tf
@@ -46,3 +46,8 @@ variable "virtual_subnets" {
 variable "vnet_integration" {
   default = {}
 }
+
+variable "external_app_settings" {
+  default = false
+  
+}

--- a/modules/messaging/servicebus/namespace/main.tf
+++ b/modules/messaging/servicebus/namespace/main.tf
@@ -10,5 +10,5 @@ terraform {
 locals {
   location            = can(var.settings.location) ? var.settings.location : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].location
   resource_group_name = can(var.settings.resource_group_name) || can(var.settings.resource_group.name) ? try(var.settings.resource_group_name, var.settings.resource_group.name) : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].name
-  base_tags           = try(var.global_settings.inherit_tags, false)
+  base_tags           = can(var.settings.base_tags) ?  var.settings.base_tags : try(var.global_settings.inherit_tags, false)
 }

--- a/modules/messaging/servicebus/namespace/main.tf
+++ b/modules/messaging/servicebus/namespace/main.tf
@@ -11,7 +11,7 @@ locals {
   location            = can(var.settings.location) ? var.settings.location : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].location
   resource_group_name = can(var.settings.resource_group_name) || can(var.settings.resource_group.name) ? try(var.settings.resource_group_name, var.settings.resource_group.name) : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].name
   base_tags           = can(var.settings.base_tags) ?  var.settings.base_tags : try(var.global_settings.inherit_tags, false)
-  tags = var.base_tags ? merge(
+  tags = local.base_tags ? merge(
     var.global_settings.tags,
     var.tags,
     try(var.settings.tags, null)

--- a/modules/messaging/servicebus/namespace/main.tf
+++ b/modules/messaging/servicebus/namespace/main.tf
@@ -13,7 +13,6 @@ locals {
   base_tags           = can(var.settings.base_tags) ?  var.settings.base_tags : try(var.global_settings.inherit_tags, false)
   tags = local.base_tags ? merge(
     var.global_settings.tags,
-    var.tags,
     try(var.settings.tags, null)
   ) : try(var.settings.tags, null)
 }

--- a/modules/messaging/servicebus/namespace/main.tf
+++ b/modules/messaging/servicebus/namespace/main.tf
@@ -11,4 +11,9 @@ locals {
   location            = can(var.settings.location) ? var.settings.location : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].location
   resource_group_name = can(var.settings.resource_group_name) || can(var.settings.resource_group.name) ? try(var.settings.resource_group_name, var.settings.resource_group.name) : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].name
   base_tags           = can(var.settings.base_tags) ?  var.settings.base_tags : try(var.global_settings.inherit_tags, false)
+  tags = var.base_tags ? merge(
+    var.global_settings.tags,
+    var.tags,
+    try(var.settings.tags, null)
+  ) : try(var.settings.tags, null)
 }

--- a/modules/messaging/servicebus/namespace/main.tf
+++ b/modules/messaging/servicebus/namespace/main.tf
@@ -10,5 +10,5 @@ terraform {
 locals {
   location            = can(var.settings.location) ? var.settings.location : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].location
   resource_group_name = can(var.settings.resource_group_name) || can(var.settings.resource_group.name) ? try(var.settings.resource_group_name, var.settings.resource_group.name) : var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].name
-  base_tags           = try(var.global_settings.inherit_tags, false) ? var.remote_objects.resource_groups[try(var.settings.resource_group.lz_key, var.client_config.landingzone_key)][var.settings.resource_group.key].tags : {}
+  base_tags           = try(var.global_settings.inherit_tags, false)
 }

--- a/modules/messaging/servicebus/namespace/namespace.tf
+++ b/modules/messaging/servicebus/namespace/namespace.tf
@@ -15,7 +15,7 @@ resource "azurerm_servicebus_namespace" "namespace" {
   sku                 = var.settings.sku
   capacity            = try(var.settings.capacity, null)
   zone_redundant      = try(var.settings.zone_redundant, null)
-  tags                = merge(local.base_tags, try(var.settings.tags, {}))
+  tags                = local.tags
   location            = local.location
   resource_group_name = local.resource_group_name
 }

--- a/modules/messaging/servicebus/namespace/private_endpoints.tf
+++ b/modules/messaging/servicebus/namespace/private_endpoints.tf
@@ -2,14 +2,14 @@ module "private_endpoint" {
   source   = "../../../networking/private_endpoint"
   for_each = try(var.settings.private_endpoints, {})
 
-  base_tags       = local.base_tags
-  client_config   = var.client_config
-  global_settings = var.global_settings
-  location        = local.location
-  name            = each.value.name
-  private_dns     = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
-  resource_groups = var.resource_groups
-  resource_id     = azurerm_servicebus_namespace.namespace.id
-  settings        = each.value
-  subnet_id       = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
+  base_tags           = local.base_tags
+  client_config       = var.client_config
+  global_settings     = var.global_settings
+  location            = local.location
+  name                = each.value.name
+  private_dns         = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
+  resource_group_name = local.resource_group.name
+  resource_id         = azurerm_servicebus_namespace.namespace.id
+  settings            = each.value
+  subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id
 }

--- a/modules/messaging/servicebus/namespace/private_endpoints.tf
+++ b/modules/messaging/servicebus/namespace/private_endpoints.tf
@@ -8,7 +8,7 @@ module "private_endpoint" {
   location            = local.location
   name                = each.value.name
   private_dns         = can(each.value.private_dns) ? var.remote_objects.private_dns : {}
-  resource_group_name = local.resource_group.name
+  resource_group_name = local.resource_group_name
   resource_id         = azurerm_servicebus_namespace.namespace.id
   settings            = each.value
   subnet_id           = can(each.value.subnet_id) ? each.value.subnet_id : var.remote_objects.vnets[try(each.value.lz_key, var.client_config.landingzone_key)][each.value.vnet_key].subnets[each.value.subnet_key].id

--- a/modules/messaging/servicebus/namespace/variables.tf
+++ b/modules/messaging/servicebus/namespace/variables.tf
@@ -17,5 +17,6 @@ variable "resource_groups" {
 }
 
 variable "tags" {
+  default = {}
   
 }

--- a/modules/messaging/servicebus/namespace/variables.tf
+++ b/modules/messaging/servicebus/namespace/variables.tf
@@ -15,8 +15,3 @@ variable "resource_groups" {
   description = "Combined resource groups object."
   default     = {}
 }
-
-variable "tags" {
-  default = {}
-  
-}

--- a/modules/messaging/servicebus/namespace/variables.tf
+++ b/modules/messaging/servicebus/namespace/variables.tf
@@ -15,3 +15,7 @@ variable "resource_groups" {
   description = "Combined resource groups object."
   default     = {}
 }
+
+variable "tags" {
+  
+}


### PR DESCRIPTION
Servicebus private endpoints module fixes:

- Tagging fixed to use the "base_tags" booleans.
- resource_group local corrected
- logic app module fixed by adding new external_app_settings variable declaration

