### PR TITLE
Fix/logic app combined objects

### DIFF
--- a/logic_app.tf
+++ b/logic_app.tf
@@ -156,6 +156,7 @@ module "logic_app_standard" {
   virtual_subnets       = local.combined_objects_virtual_subnets
   base_tags             = try(local.global_settings.inherit_tags, false)
   vnet_integration      = try(each.value.vnet_integration, {})
+  combined_objects      = local.dynamic_app_settings_combined_objects
 }
 
 output "logic_app_standard" {

--- a/modules/logic_app/standard/locals.dynamic_app_settings.tf
+++ b/modules/logic_app/standard/locals.dynamic_app_settings.tf
@@ -1,0 +1,27 @@
+locals {
+  # Expected Variable: dynamic_app_settings = {
+  #                      "KEYVAULT_URL" = {
+  #                         keyvaults = {
+  #                           my_common_vault = {
+  #                             lz_key = "common_services_lz"
+  #                             attribute_key = "vault_uri"
+  #                           }
+  #                         }
+  #                      }
+  #                     }
+  dynamic_settings_to_process = {
+    for setting in
+    flatten(
+      [
+        for setting_name, resources in var.dynamic_app_settings : [
+          for resource_type_key, resource in resources : [
+            for object_id_key, object_attributes in resource : {
+              key   = setting_name
+              value = try(var.combined_objects[resource_type_key][object_attributes.lz_key][object_id_key][object_attributes.attribute_key], var.combined_objects[resource_type_key][var.client_config.landingzone_key][object_id_key][object_attributes.attribute_key])
+            }
+          ]
+        ]
+      ]
+    ) : setting.key => setting.value
+  }
+}

--- a/modules/logic_app/standard/module.tf
+++ b/modules/logic_app/standard/module.tf
@@ -19,6 +19,15 @@ resource "azurerm_logic_app_standard" "logic_app_standard" {
 
   app_settings = local.app_settings
 
+  dynamic "identity" {
+    for_each = try(var.identity, null) == null ? [] : [1]
+
+    content {
+      type         = var.identity.type
+      identity_ids = lower(var.identity.type) == "userassigned" ? local.managed_identities : null
+    }
+  }
+
   dynamic "site_config" {
     for_each = lookup(var.settings, "site_config", {}) != {} ? [1] : []
 

--- a/modules/logic_app/standard/variables.tf
+++ b/modules/logic_app/standard/variables.tf
@@ -49,3 +49,7 @@ variable "vnet_integration" {
 variable "external_app_settings" {
   default = false
 }
+
+variable "dynamic_app_settings" {
+  default = {}
+}


### PR DESCRIPTION
Logic app module did not contain the variables needed to support managed identities lookup:
- added combined_objects variable to module call
- added locals.dynamic_app_settings.tf which creates the combined_objects object
- added variable declaration for dynamic_app_settings
- added dynamic identity block to the logic app module so that it can set the identity

**NOTE: the managed Identity is linked to the underlying app service app and does not show up in the logic app blade itself
This could be a azure portal GUI error or perhaps this is not supported fully  yet, here is a thread that mentioned that this feature was only added last year to the Azure REST API (https://github.com/hashicorp/terraform-provider-azurerm/issues/2924)**